### PR TITLE
fix shebang

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,4 +1,4 @@
-#! /bin/sh
+#! /usr/bin/bash
 # Copyright (C) 2018 Igara Studio S.A.
 # Copyright (C) 2018 David Capello
 


### PR DESCRIPTION
The `run-tests.sh` script in not actually `sh` compliant - using `sh` (explicitely or by shebang) to execute the script will therefore crash with syntax errors.
With this change you can invoke the script as just `./run-tests.sh` as opposed to the explicit `bash run-tests.sh` you currently use - but either will work.